### PR TITLE
[BB-9767] Reset current slide when count is changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         python-version: [3.8, 3.11, 3.12]
         toxenv: [django42, quality, translations]
 

--- a/multi_problem_xblock/multi_problem_xblock.py
+++ b/multi_problem_xblock/multi_problem_xblock.py
@@ -368,6 +368,15 @@ class MultiProblemBlock(LibraryContentBlock):
         if overall_progress == 100 and self.current_slide == -1 and self.display_feedback == DISPLAYFEEDBACK.NEVER:
             self.current_slide = 0
 
+        # Clamp current_slide to a valid index when the number of items changes
+        # Keep -1 as a special value to show the test results slide
+        num_items = len(items)
+        if self.current_slide != -1:
+            if num_items == 0:
+                self.current_slide = 0
+            elif self.current_slide >= num_items:
+                self.current_slide = 0
+
         template_context = {
             'items': items,
             'self': self,

--- a/multi_problem_xblock/multi_problem_xblock.py
+++ b/multi_problem_xblock/multi_problem_xblock.py
@@ -372,9 +372,7 @@ class MultiProblemBlock(LibraryContentBlock):
         # Keep -1 as a special value to show the test results slide
         num_items = len(items)
         if self.current_slide != -1:
-            if num_items == 0:
-                self.current_slide = 0
-            elif self.current_slide >= num_items:
+            if self.current_slide < -1 or self.current_slide >= num_items:
                 self.current_slide = 0
 
         template_context = {

--- a/multi_problem_xblock/multi_problem_xblock.py
+++ b/multi_problem_xblock/multi_problem_xblock.py
@@ -371,9 +371,8 @@ class MultiProblemBlock(LibraryContentBlock):
         # Clamp current_slide to a valid index when the number of items changes
         # Keep -1 as a special value to show the test results slide
         num_items = len(items)
-        if self.current_slide != -1:
-            if self.current_slide < -1 or self.current_slide >= num_items:
-                self.current_slide = 0
+        if self.current_slide < -1 or self.current_slide >= num_items:
+            self.current_slide = 0
 
         template_context = {
             'items': items,

--- a/multi_problem_xblock/public/js/multi_problem_xblock.js
+++ b/multi_problem_xblock/public/js/multi_problem_xblock.js
@@ -24,6 +24,10 @@ function MultiProblemBlock(runtime, element, initArgs) {
 
   function showSlide(num) {
     var slides = $('.slide', element);
+    // Guard against out-of-range indices
+    if (num < 0 || num >= slides.length) {
+      num = 0;
+    }
     slides[num].style.display = "block";
     //... and fix the Previous/Next buttons:
     if (num == 0) {
@@ -55,8 +59,8 @@ function MultiProblemBlock(runtime, element, initArgs) {
     var slides = $('.slide', element);
     // Calculate next slide position
     var nextSlide = currentSlide + num;
-    // if you have reached the end of the form...
-    if (nextSlide >= slides.length) {
+    // if you have reached the end or before start of the form...
+    if (nextSlide < 0 || nextSlide >= slides.length) {
       return false;
     }
     // Hide the current tab:
@@ -174,6 +178,11 @@ function MultiProblemBlock(runtime, element, initArgs) {
   if (currentSlide === -1) {
     $('.see-test-results', element).trigger('click');
   } else {
+    // Ensure initial slide index is valid
+    var initSlides = $('.slide', element);
+    if (currentSlide >= initSlides.length) {
+      currentSlide = 0;
+    }
     showSlide(currentSlide)
   }
 

--- a/multi_problem_xblock/templates/html/multi_problem_xblock.html
+++ b/multi_problem_xblock/templates/html/multi_problem_xblock.html
@@ -16,9 +16,11 @@
       </button>
       <div class="text-center">
         <small class="slide-position text-gray">
-          {% blocktrans with items_length=items|length current_slide=self.current_slide %}
-          {{ current_slide }} of {{ items_length }}
+          {% with current_position=self.current_slide|add:1 total=items|length %}
+          {% blocktrans with current_position=current_position total=total %}
+          {{ current_position }} of {{ total }}
           {% endblocktrans %}
+          {% endwith %}
         </small>
         {% if self.display_name %}
         <h2 class="hd hd-2">{{ self.display_name }}</h2>

--- a/multi_problem_xblock/templates/html/multi_problem_xblock.html
+++ b/multi_problem_xblock/templates/html/multi_problem_xblock.html
@@ -16,11 +16,9 @@
       </button>
       <div class="text-center">
         <small class="slide-position text-gray">
-          {% with current_position=self.current_slide|add:1 total=items|length %}
-          {% blocktrans with current_position=current_position total=total %}
+          {% blocktrans with current_position=self.current_slide|add:1 total=items|length %}
           {{ current_position }} of {{ total }}
           {% endblocktrans %}
-          {% endwith %}
         </small>
         {% if self.display_name %}
         <h2 class="hd hd-2">{{ self.display_name }}</h2>


### PR DESCRIPTION
## Description

This PR fixes the issue with the current slide not being reset when the count is updated in the settings.

## Supporting information

OpenCraft Internal Jira task: [BB-9767](https://tasks.opencraft.com/browse/BB-9767)

## Testing instructions

1. Deploy earlier version of this xblock and replicate the "Multi-problem - library count" issue documented in the task.
2. Checkout this PR branch.
3. Verify that the published version updates correctly when the count is updated in the xblock settings.


## Other information

The task includes two other issues reported for the multi-problem xblock:
**1. Multi-problem - Advanced Editor:**
Unable to reproduce this on the instance - likely something wrong with their own instance (not hosted by OpenCraft) specifically with the MFE setup, since clicking on edit is supposed to open the course-authoring MFE.
**2. Multi-problem - No preview and Error:**
Unable to reproduce on the instance - text as well as numeric input type questions are working as expected. Likely related to their own instance.
